### PR TITLE
Prevent other terminals from being killed when creating TmpFS

### DIFF
--- a/TmpDisk/TmpDiskManager.swift
+++ b/TmpDisk/TmpDiskManager.swift
@@ -272,14 +272,10 @@ class TmpDiskManager {
         let task = Process()
         task.launchPath = "/usr/bin/osascript"
         let command = "mount_tmpfs -s\(volume.size)M \(volume.path())"
-        
         let script = """
-        tell application "Terminal"
             do shell script "\(command)" with administrator privileges
-            quit
-        end tell
         """
-        
+
         task.arguments = ["-e", script]
         return task
     }


### PR DESCRIPTION
I replaced the script used to create TmpFS so that it will not force the user to terminate all Terminal windows.