### PR TITLE
Add zh-Hans translations for UI and prompts

### DIFF
--- a/TmpDisk/zh-Hans.lproj/Localizable.strings
+++ b/TmpDisk/zh-Hans.lproj/Localizable.strings
@@ -27,3 +27,5 @@
 "The volume \"%@\" wasn't ejected because one or more programs may be using it" = "无法推出卷 \"%@\" , 因为有一个或多个程序正在使用";
 "To eject the disk immediately, hit the Force Eject button" = "选择\"强制推出\"按钮以强制推出";
 "Force Eject" = "强制推出";
+"Do you wish to install TmpDiskHelper? It will require your admin password." = "您想安装 TmpDiskHelper 吗？需要管理员密码确认。";
+"There is an updated TmpDiskHelper, do you wish to install it? Requires admin password." = "有一个新版的 TmpDiskHelper，您想安装吗？需要管理员密码确认。";

--- a/TmpDisk/zh-Hans.lproj/Main.strings
+++ b/TmpDisk/zh-Hans.lproj/Main.strings
@@ -577,3 +577,6 @@
 
 /* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "z6F-FW-3nz"; */
 "z6F-FW-3nz.title" = "Show Substitutions";
+
+/* Class = "NSTextFieldCell"; title = "Installing the TmpDiskCreator Helper can install TmpFS TmpDisks without asking for your root password. Requires Admin password to install"; ObjectID = "LLv-lK-dgg"; */
+"LLv-lK-dgg.title" = "安装 TmpDiskHelper 后，无需输入 root 密码即可创建 TmpFS 临时磁盘。安装时需要管理员密码";


### PR DESCRIPTION
Added zh-Hans translations:
- UI text in Main.strings, adjusted for aesthetic alignment due to `alignment="center"` in Main.storyboard.
- Prompts in Localizable.strings from Util.swift.

Please feel free to suggest any revisions if needed.

