### PR TITLE
Add Japanese translation

### DIFF
--- a/TmpDisk/ja.lproj/Localizable.strings
+++ b/TmpDisk/ja.lproj/Localizable.strings
@@ -1,0 +1,29 @@
+/* 
+  Localizable.strings
+  TmpDisk
+
+  Translated by maboroshin. (2025-08-08)
+  
+*/
+
+"New TmpDisk" = "新規 TmpDisk";
+"Current TmpDisks" = "現在の TmpDisks";
+"Recreate All" = "すべて再作成";
+"AutoCreate Manager" = "自動作成の管理";
+"Always Start on Login" = "ログイン時に起動する";
+"Check for Updates" = "更新確認";
+"About TmpDisk" = "TmpDisk について";
+"Quit" = "終了";
+"Your TmpDisk must have a name" = "TmpDisk には名前が必要です";
+"A volume with this name already exists" = "この名前のボリュームは既に存在します";
+"Size must be a number of megabytes > 0" = "メガバイトのサイズは 0 以上の数字にしてください";
+"Size must be a number of gigabytes >= 0.01" = "ギガバイトのサイズは 0.01 以上の数字にしてください";
+"Failed to create TmpDisk" = "TmpDisk 作成に失敗";
+"Preferences" = "設定";
+"You can't change the root volume while tmpFS disks are mounted." = "tmpFS ディスクがマウントされている間は、ルートボリュームを変更できません。";
+"Icon must be square" = "アイコンは正方形にしてください";
+"Could not convert image to icon" = "画像をアイコンに変換できません";
+"Failed to eject \"%@\"" = "取り出しに失敗 \"%@\"";
+"The volume \"%@\" wasn't ejected because one or more programs may be using it" = "ボリューム \"%@\" を取り出せません。1つ以上のアプリが使用中です";
+"To eject the disk immediately, hit the Force Eject button" = "すぐにこのディスクを取り出すには、強制的に取り出しボタンを押してください";
+"Force Eject" = "強制的に取り出し";

--- a/TmpDisk/ja.lproj/Main.strings
+++ b/TmpDisk/ja.lproj/Main.strings
@@ -1,0 +1,585 @@
+
+/* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1UK-8n-QPP"; */
+"1UK-8n-QPP.title" = "ツールバーの編集…";
+
+/* Class = "NSMenuItem"; title = "TmpDisk"; ObjectID = "1Xt-HY-uBw"; */
+"1Xt-HY-uBw.title" = "TmpDisk";
+
+/* Class = "NSMenu"; title = "Find"; ObjectID = "1b7-l0-nxx"; */
+"1b7-l0-nxx.title" = "検索";
+
+/* Class = "NSButtonCell"; title = "Spotlight Index Volume"; ObjectID = "1jo-cE-WNd"; */
+"1jo-cE-WNd.title" = "Spotlight インデックスボリューム";
+
+/* Class = "NSMenuItem"; title = "Lower"; ObjectID = "1tx-W0-xDw"; */
+"1tx-W0-xDw.title" = "Lower";
+
+/* Class = "NSMenuItem"; title = "Raise"; ObjectID = "2h7-ER-AoG"; */
+"2h7-ER-AoG.title" = "Raise";
+
+/* Class = "NSMenuItem"; title = "Transformations"; ObjectID = "2oI-Rn-ZJC"; */
+"2oI-Rn-ZJC.title" = "Transformations";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "2yo-HM-UnI"; */
+"2yo-HM-UnI.title" = "Text Cell";
+
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "3IN-sU-3Bg"; */
+"3IN-sU-3Bg.title" = "Spelling";
+
+/* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "3Om-Ey-2VK"; */
+"3Om-Ey-2VK.title" = "Use Default";
+
+/* Class = "NSMenu"; title = "Speech"; ObjectID = "3rS-ZA-NoH"; */
+"3rS-ZA-NoH.title" = "Speech";
+
+/* Class = "NSMenuItem"; title = "Tighten"; ObjectID = "46P-cB-AYj"; */
+"46P-cB-AYj.title" = "Tighten";
+
+/* Class = "NSMenuItem"; title = "Find"; ObjectID = "4EN-yA-p0u"; */
+"4EN-yA-p0u.title" = "検索";
+
+/* Class = "NSMenuItem"; title = "Enter Full Screen"; ObjectID = "4J7-dP-txa"; */
+"4J7-dP-txa.title" = "全画面にする";
+
+/* Class = "NSTextFieldCell"; title = "Disk Name"; ObjectID = "4jY-m0-8Zh"; */
+"4jY-m0-8Zh.title" = "ディスク名";
+
+/* Class = "NSMenuItem"; title = "Quit TmpDisk"; ObjectID = "4sb-4s-VLi"; */
+"4sb-4s-VLi.title" = "TmpDisk を終了";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "5D4-lB-5pZ"; */
+"5D4-lB-5pZ.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "5QF-Oa-p0T"; */
+"5QF-Oa-p0T.title" = "編集";
+
+/* Class = "NSMenuItem"; title = "Copy Style"; ObjectID = "5Vv-lz-BsD"; */
+"5Vv-lz-BsD.title" = "Copy Style";
+
+/* Class = "NSTextFieldCell"; placeholderString = "You must enter a Disk Name"; ObjectID = "5ee-ag-nb5"; */
+"5ee-ag-nb5.placeholderString" = "ディスク名を入力してください";
+
+/* Class = "NSMenuItem"; title = "About TmpDisk"; ObjectID = "5kV-Vb-QxS"; */
+"5kV-Vb-QxS.title" = "TmpDisk について";
+
+/* Class = "NSTableColumn"; headerCell.title = "TmpFS"; ObjectID = "60P-FP-R7L"; */
+"60P-FP-R7L.headerCell.title" = "TmpFS";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "6dh-zS-Vam"; */
+"6dh-zS-Vam.title" = "やり直し";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "6q7-5O-jmd"; */
+"6q7-5O-jmd.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Correct Spelling Automatically"; ObjectID = "78Y-hA-62v"; */
+"78Y-hA-62v.title" = "自動でつづりを修正";
+
+/* Class = "NSTextFieldCell"; title = "https://github.com/imothee/tmpdisk/issues"; ObjectID = "7B3-Xk-LWU"; */
+"7B3-Xk-LWU.title" = "https://github.com/imothee/tmpdisk/issues";
+
+/* Class = "NSButtonCell"; title = "Warn on eject if TmpDisk has files"; ObjectID = "87p-Ma-bcT"; */
+"87p-Ma-bcT.title" = "TmpDisk にファイルが存在すれば、取り出し時に警告する";
+
+/* Class = "NSTextFieldCell"; title = "https://github.com/imothee/tmpdisk"; ObjectID = "8Lb-V2-Iun"; */
+"8Lb-V2-Iun.title" = "https://github.com/imothee/tmpdisk";
+
+/* Class = "NSMenu"; title = "Writing Direction"; ObjectID = "8mr-sm-Yjd"; */
+"8mr-sm-Yjd.title" = "書字方向";
+
+/* Class = "NSButtonCell"; title = "Create TmpDisk"; ObjectID = "8vB-Je-FgU"; */
+"8vB-Je-FgU.title" = "TmpDisk 作成";
+
+/* Class = "NSTextFieldCell"; title = "TmpDisk was created by @imothee to help easily create and manage Ram Disks. Distributed under GPL V2."; ObjectID = "92J-GX-lZp"; */
+"92J-GX-lZp.title" = "TmpDisk は @imothee が開発しました。RAM ディスクの作成と管理を簡単にします。GPL V2ライセンスで頒布されています。";
+
+/* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "9ic-FL-obx"; */
+"9ic-FL-obx.title" = "Substitutions";
+
+/* Class = "NSMenuItem"; title = "Smart Copy/Paste"; ObjectID = "9yt-4B-nSM"; */
+"9yt-4B-nSM.title" = "スマートコピー/ペースト";
+
+/* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
+"AYu-sK-qS6.title" = "Main Menu";
+
+/* Class = "NSTableColumn"; headerCell.title = "Disk Size"; ObjectID = "AkQ-t6-iWy"; */
+"AkQ-t6-iWy.headerCell.title" = "ディスク容量";
+
+/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "設定…";
+
+/* Class = "NSMenuItem"; title = "\tLeft to Right"; ObjectID = "BgM-ve-c93"; */
+"BgM-ve-c93.title" = "\t左から右へ";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "Bic-Cu-iR6"; */
+"Bic-Cu-iR6.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Save As…"; ObjectID = "Bw7-FT-i3A"; */
+"Bw7-FT-i3A.title" = "別名で保存…";
+
+/* Class = "NSTextFieldCell"; title = "Found a bug or Issue?"; ObjectID = "CRo-x0-OMs"; */
+"CRo-x0-OMs.title" = "バグや問題がありますか?";
+
+/* Class = "NSMenuItem"; title = "10% of Ram"; ObjectID = "DAh-6M-Jca"; */
+"DAh-6M-Jca.title" = "RAM の 10%";
+
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
+"DVo-aG-piG.title" = "閉じる";
+
+/* Class = "NSMenuItem"; title = "Spelling and Grammar"; ObjectID = "Dv1-io-Yv7"; */
+"Dv1-io-Yv7.title" = "スペルと文法";
+
+/* Class = "NSTableColumn"; headerCell.title = "Journaled"; ObjectID = "EOg-1b-WmF"; */
+"EOg-1b-WmF.headerCell.title" = "ジャーナリング";
+
+/* Class = "NSTextFieldCell"; title = "Change where your TmpFS mount points sit. Must be changed when you have no TmpFS volumes mounted."; ObjectID = "EYH-BL-kNS"; */
+"EYH-BL-kNS.title" = "TmpFS のマウントポイントの場所を変更します。TmpFS ボリュームがマウントされていない状態で変更してください。";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
+"F2S-fz-NVQ.title" = "ヘルプ";
+
+/* Class = "NSMenuItem"; title = "TmpDisk Help"; ObjectID = "FKE-Sm-Kum"; */
+"FKE-Sm-Kum.title" = "TmpDisk ヘルプ";
+
+/* Class = "NSMenuItem"; title = "Text"; ObjectID = "Fal-I4-PZk"; */
+"Fal-I4-PZk.title" = "テキスト";
+
+/* Class = "NSMenu"; title = "Substitutions"; ObjectID = "FeM-D8-WVr"; */
+"FeM-D8-WVr.title" = "Substitutions";
+
+/* Class = "NSMenuItem"; title = "Bold"; ObjectID = "GB9-OM-e27"; */
+"GB9-OM-e27.title" = "Bold";
+
+/* Class = "NSMenu"; title = "Format"; ObjectID = "GEO-Iw-cKr"; */
+"GEO-Iw-cKr.title" = "フォーマット";
+
+/* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "GUa-eO-cwY"; */
+"GUa-eO-cwY.title" = "標準を使用";
+
+/* Class = "NSMenuItem"; title = "Font"; ObjectID = "Gi5-1S-RQB"; */
+"Gi5-1S-RQB.title" = "フォント";
+
+/* Class = "NSMenuItem"; title = "Writing Direction"; ObjectID = "H1b-Si-o9J"; */
+"H1b-Si-o9J.title" = "書字方向";
+
+/* Class = "NSMenuItem"; title = "View"; ObjectID = "H8h-7b-M4v"; */
+"H8h-7b-M4v.title" = "表示";
+
+/* Class = "NSMenuItem"; title = "Text Replacement"; ObjectID = "HFQ-gK-NFA"; */
+"HFQ-gK-NFA.title" = "テキストを置換";
+
+/* Class = "NSMenuItem"; title = "Show Spelling and Grammar"; ObjectID = "HFo-cy-zxI"; */
+"HFo-cy-zxI.title" = "スペルと文法を表示";
+
+/* Class = "NSMenu"; title = "View"; ObjectID = "HyV-fh-RgO"; */
+"HyV-fh-RgO.title" = "表示";
+
+/* Class = "NSMenuItem"; title = "Subscript"; ObjectID = "I0S-gh-46l"; */
+"I0S-gh-46l.title" = "Subscript";
+
+/* Class = "NSMenuItem"; title = "Open…"; ObjectID = "IAo-SY-fd9"; */
+"IAo-SY-fd9.title" = "開く…";
+
+/* Class = "NSMenuItem"; title = "Justify"; ObjectID = "J5U-5w-g23"; */
+"J5U-5w-g23.title" = "Justify";
+
+/* Class = "NSMenuItem"; title = "Use None"; ObjectID = "J7y-lM-qPV"; */
+"J7y-lM-qPV.title" = "Use None";
+
+/* Class = "NSTextFieldCell"; title = "Icon"; ObjectID = "JAg-eR-WFV"; */
+"JAg-eR-WFV.title" = "アイコン";
+
+/* Class = "NSMenuItem"; title = "MB"; ObjectID = "JxI-0N-oYo"; */
+"JxI-0N-oYo.title" = "MB";
+
+/* Class = "NSMenuItem"; title = "Revert to Saved"; ObjectID = "KaW-ft-85H"; */
+"KaW-ft-85H.title" = "保存済みに戻す";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "Kd2-mp-pUS"; */
+"Kd2-mp-pUS.title" = "すべて表示";
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "LE2-aR-0XJ"; */
+"LE2-aR-0XJ.title" = "すべてを前面に表示";
+
+/* Class = "NSMenuItem"; title = "Paste Ruler"; ObjectID = "LVM-kO-fVI"; */
+"LVM-kO-fVI.title" = "Paste Ruler";
+
+/* Class = "NSMenuItem"; title = "\tLeft to Right"; ObjectID = "Lbh-J2-qVU"; */
+"Lbh-J2-qVU.title" = "\t左から右へ";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "Lnn-2h-S6l"; */
+"Lnn-2h-S6l.title" = "Text Cell";
+
+/* Class = "NSButtonCell"; title = "AutoCreate when TmpDisk Starts"; ObjectID = "MLQ-EB-OE8"; */
+"MLQ-EB-OE8.title" = "TmpDisk 起動時に自動作成";
+
+/* Class = "NSMenuItem"; title = "Copy Ruler"; ObjectID = "MkV-Pr-PK5"; */
+"MkV-Pr-PK5.title" = "Copy Ruler";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "NMo-om-nkz"; */
+"NMo-om-nkz.title" = "サービス";
+
+/* Class = "NSMenuItem"; title = "\tDefault"; ObjectID = "Nop-cj-93Q"; */
+"Nop-cj-93Q.title" = "\tDefault";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
+"OY7-WF-poV.title" = "最小化";
+
+/* Class = "NSMenuItem"; title = "Baseline"; ObjectID = "OaQ-X3-Vso"; */
+"OaQ-X3-Vso.title" = "Baseline";
+
+/* Class = "NSTableColumn"; headerCell.title = "Folders"; ObjectID = "Oae-Gb-smK"; */
+"Oae-Gb-smK.headerCell.title" = "フォルダ";
+
+/* Class = "NSMenuItem"; title = "Hide TmpDisk"; ObjectID = "Olw-nP-bQN"; */
+"Olw-nP-bQN.title" = "TmpDisk を非表示";
+
+/* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "OwM-mh-QMV"; */
+"OwM-mh-QMV.title" = "Find Previous";
+
+/* Class = "NSMenuItem"; title = "Stop Speaking"; ObjectID = "Oyz-dy-DGm"; */
+"Oyz-dy-DGm.title" = "Stop Speaking";
+
+/* Class = "NSWindow"; title = "Preferences"; ObjectID = "PIG-yb-FRO"; */
+"PIG-yb-FRO.title" = "設定";
+
+/* Class = "NSMenuItem"; title = "Bigger"; ObjectID = "Ptp-SP-VEL"; */
+"Ptp-SP-VEL.title" = "Bigger";
+
+/* Class = "NSMenuItem"; title = "Show Fonts"; ObjectID = "Q5e-8K-NDq"; */
+"Q5e-8K-NDq.title" = "フォントを表示";
+
+/* Class = "NSMenuItem"; title = "GB"; ObjectID = "QDX-KN-Ki5"; */
+"QDX-KN-Ki5.title" = "GB";
+
+/* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "R4o-n2-Eq4"; */
+"R4o-n2-Eq4.title" = "拡大";
+
+/* Class = "NSMenuItem"; title = "\tRight to Left"; ObjectID = "RB4-Sm-HuC"; */
+"RB4-Sm-HuC.title" = "\t右から左へ";
+
+/* Class = "NSMenuItem"; title = "Superscript"; ObjectID = "Rqc-34-cIF"; */
+"Rqc-34-cIF.title" = "Superscript";
+
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "Ruw-6m-B2m"; */
+"Ruw-6m-B2m.title" = "すべて選択";
+
+/* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "S0p-oC-mLd"; */
+"S0p-oC-mLd.title" = "Jump to Selection";
+
+/* Class = "NSMenu"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
+"Td7-aD-5lo.title" = "ウィンドウ";
+
+/* Class = "NSWindow"; title = "AutoCreate Manager"; ObjectID = "TsY-Lt-YWL"; */
+"TsY-Lt-YWL.title" = "自動作成の管理ツール";
+
+/* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "UEZ-Bs-lqG"; */
+"UEZ-Bs-lqG.title" = "Capitalize";
+
+/* Class = "NSTableColumn"; headerCell.title = "Case Sensitive"; ObjectID = "UPy-wU-HZo"; */
+"UPy-wU-HZo.headerCell.title" = "Case Sensitive";
+
+/* Class = "NSMenuItem"; title = "Center"; ObjectID = "VIY-Ag-zcb"; */
+"VIY-Ag-zcb.title" = "Center";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "Vdr-fp-XzO"; */
+"Vdr-fp-XzO.title" = "ほかを非表示";
+
+/* Class = "NSMenuItem"; title = "Italic"; ObjectID = "Vjx-xi-njq"; */
+"Vjx-xi-njq.title" = "斜体";
+
+/* Class = "NSButtonCell"; title = "x"; ObjectID = "VlQ-Mr-VAu"; */
+"VlQ-Mr-VAu.title" = "x";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "W48-6f-4Dl"; */
+"W48-6f-4Dl.title" = "編集";
+
+/* Class = "NSMenuItem"; title = "Underline"; ObjectID = "WRG-CD-K1S"; */
+"WRG-CD-K1S.title" = "Underline";
+
+/* Class = "NSMenuItem"; title = "New"; ObjectID = "Was-JA-tGl"; */
+"Was-JA-tGl.title" = "新規";
+
+/* Class = "NSMenuItem"; title = "Paste and Match Style"; ObjectID = "WeT-3V-zwk"; */
+"WeT-3V-zwk.title" = "Paste and Match Style";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "XWF-fr-bC7"; */
+"XWF-fr-bC7.title" = "Table View Cell";
+
+/* Class = "NSMenuItem"; title = "Find…"; ObjectID = "Xz5-n4-O0W"; */
+"Xz5-n4-O0W.title" = "検索…";
+
+/* Class = "NSTextFieldCell"; title = "Disk Size"; ObjectID = "YCV-8p-NZK"; */
+"YCV-8p-NZK.title" = "ディスク容量";
+
+/* Class = "NSMenuItem"; title = "Find and Replace…"; ObjectID = "YEy-JH-Tfz"; */
+"YEy-JH-Tfz.title" = "検索と置換…";
+
+/* Class = "NSMenuItem"; title = "\tDefault"; ObjectID = "YGs-j5-SAR"; */
+"YGs-j5-SAR.title" = "\tDefault";
+
+/* Class = "NSTextFieldCell"; title = "Get the source code"; ObjectID = "YQl-gW-wMR"; */
+"YQl-gW-wMR.title" = "ソースコードを参照";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "YRf-Nm-YtA"; */
+"YRf-Nm-YtA.title" = "Text Cell";
+
+/* Class = "NSTextFieldCell"; title = "3rd Party Libraries"; ObjectID = "Yhh-3o-HGQ"; */
+"Yhh-3o-HGQ.title" = "第三者製ライブラリ";
+
+/* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "Ynk-f8-cLZ"; */
+"Ynk-f8-cLZ.title" = "Start Speaking";
+
+/* Class = "NSMenuItem"; title = "Align Left"; ObjectID = "ZM1-6Q-yy1"; */
+"ZM1-6Q-yy1.title" = "Align Left";
+
+/* Class = "NSMenuItem"; title = "Paragraph"; ObjectID = "ZvO-Gk-QUH"; */
+"ZvO-Gk-QUH.title" = "Paragraph";
+
+/* Class = "NSButtonCell"; title = "Update Preferences"; ObjectID = "aFz-gK-uoy"; */
+"aFz-gK-uoy.title" = "設定を更新";
+
+/* Class = "NSMenuItem"; title = "Print…"; ObjectID = "aTl-1u-JFS"; */
+"aTl-1u-JFS.title" = "印刷…";
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "aUF-d1-5bR"; */
+"aUF-d1-5bR.title" = "ウインドウ";
+
+/* Class = "NSMenu"; title = "Font"; ObjectID = "aXa-aM-Jaq"; */
+"aXa-aM-Jaq.title" = "フォント";
+
+/* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "agt-UL-0e3"; */
+"agt-UL-0e3.title" = "標準を使用";
+
+/* Class = "NSMenuItem"; title = "Show Colors"; ObjectID = "bgn-CT-cEk"; */
+"bgn-CT-cEk.title" = "Show Colors";
+
+/* Class = "NSMenu"; title = "File"; ObjectID = "bib-Uj-vzu"; */
+"bib-Uj-vzu.title" = "ファイル";
+
+/* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "buJ-ug-pKt"; */
+"buJ-ug-pKt.title" = "Use Selection for Find";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "bvb-Pe-WVS"; */
+"bvb-Pe-WVS.headerCell.title" = "名前";
+
+/* Class = "NSMenu"; title = "Transformations"; ObjectID = "c8a-y6-VQd"; */
+"c8a-y6-VQd.title" = "Transformations";
+
+/* Class = "NSMenuItem"; title = "Use None"; ObjectID = "cDB-IK-hbR"; */
+"cDB-IK-hbR.title" = "Use None";
+
+/* Class = "NSButtonCell"; title = "Hidden Volume"; ObjectID = "cOC-Ky-V05"; */
+"cOC-Ky-V05.title" = "ボリュームを非表示";
+
+/* Class = "NSMenuItem"; title = "Selection"; ObjectID = "cqv-fj-IhA"; */
+"cqv-fj-IhA.title" = "Selection";
+
+/* Class = "NSMenuItem"; title = "Smart Links"; ObjectID = "cwL-P1-jid"; */
+"cwL-P1-jid.title" = "Smart Links";
+
+/* Class = "NSMenuItem"; title = "Make Lower Case"; ObjectID = "d9M-CD-aMd"; */
+"d9M-CD-aMd.title" = "Make Lower Case";
+
+/* Class = "NSMenu"; title = "Text"; ObjectID = "d9c-me-L2H"; */
+"d9c-me-L2H.title" = "テキスト";
+
+/* Class = "NSMenuItem"; title = "File"; ObjectID = "dMs-cI-mzQ"; */
+"dMs-cI-mzQ.title" = "ファイル";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "dRJ-4n-Yzg"; */
+"dRJ-4n-Yzg.title" = "元に戻す";
+
+/* Class = "NSTextFieldCell"; placeholderString = "~/.tmpdisk/volumes"; ObjectID = "fMk-fB-fMf"; */
+"fMk-fB-fMf.placeholderString" = "~/.tmpdisk/volumes";
+
+/* Class = "NSTableColumn"; headerCell.title = "Hidden"; ObjectID = "fP5-p8-hYR"; */
+"fP5-p8-hYR.headerCell.title" = "非表示";
+
+/* Class = "NSButtonCell"; title = "Case Sensitive"; ObjectID = "gCa-HK-wJZ"; */
+"gCa-HK-wJZ.title" = "Case Sensitive";
+
+/* Class = "NSButtonCell"; title = "Journaled"; ObjectID = "gFb-jm-Dxc"; */
+"gFb-jm-Dxc.title" = "ジャーナリング";
+
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "gVA-U4-sdL"; */
+"gVA-U4-sdL.title" = "ペースト";
+
+/* Class = "NSMenuItem"; title = "Custom"; ObjectID = "gcJ-GN-9gz"; */
+"gcJ-GN-9gz.title" = "指定";
+
+/* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "hQb-2v-fYv"; */
+"hQb-2v-fYv.title" = "Smart Quotes";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "hlg-9B-vKO"; */
+"hlg-9B-vKO.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Check Document Now"; ObjectID = "hz2-CU-CR7"; */
+"hz2-CU-CR7.title" = "Check Document Now";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
+"hz9-B4-Xy5.title" = "サービス";
+
+/* Class = "NSMenuItem"; title = "Smaller"; ObjectID = "i1d-Er-qST"; */
+"i1d-Er-qST.title" = "Smaller";
+
+/* Class = "NSMenu"; title = "Baseline"; ObjectID = "ijk-EB-dga"; */
+"ijk-EB-dga.title" = "Baseline";
+
+/* Class = "NSTextFieldCell"; placeholderString = "Comma separated folder names"; ObjectID = "ini-oz-Wpw"; */
+"ini-oz-Wpw.placeholderString" = "フォルダ名をコンマ区切りで";
+
+/* Class = "NSMenuItem"; title = "Kern"; ObjectID = "jBQ-r6-VK2"; */
+"jBQ-r6-VK2.title" = "Kern";
+
+/* Class = "NSTextFieldCell"; title = "Sparkle Framework"; ObjectID = "jFH-29-tnu"; */
+"jFH-29-tnu.title" = "Sparkle Framework";
+
+/* Class = "NSMenuItem"; title = "\tRight to Left"; ObjectID = "jFq-tB-4Kx"; */
+"jFq-tB-4Kx.title" = "\tRight to Left";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "jWq-m5-D4C"; */
+"jWq-m5-D4C.title" = "Text Cell";
+
+/* Class = "NSWindow"; title = "Create New TmpDisk"; ObjectID = "jhY-SC-DO1"; */
+"jhY-SC-DO1.title" = "TmpDisk を新規作成";
+
+/* Class = "NSMenuItem"; title = "Format"; ObjectID = "jxT-CU-nIS"; */
+"jxT-CU-nIS.title" = "フォーマット";
+
+/* Class = "NSMenuItem"; title = "Show Sidebar"; ObjectID = "kIP-vf-haE"; */
+"kIP-vf-haE.title" = "サイドバーを表示";
+
+/* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "mK6-2p-4JG"; */
+"mK6-2p-4JG.title" = "スペルと文法を確認";
+
+/* Class = "NSTableColumn"; headerCell.title = "Warn"; ObjectID = "moE-oU-Xjj"; */
+"moE-oU-Xjj.headerCell.title" = "警告";
+
+/* Class = "NSMenuItem"; title = "50% of Ram"; ObjectID = "nXv-G3-d8b"; */
+"nXv-G3-d8b.title" = "RAM の 50%";
+
+/* Class = "NSTextFieldCell"; placeholderString = "0"; ObjectID = "nYC-7d-c8X"; */
+"nYC-7d-c8X.placeholderString" = "0";
+
+/* Class = "NSTextFieldCell"; title = "16"; ObjectID = "nYC-7d-c8X"; */
+"nYC-7d-c8X.title" = "16";
+
+/* Class = "NSMenuItem"; title = "Ligatures"; ObjectID = "o6e-r0-MWq"; */
+"o6e-r0-MWq.title" = "Ligatures";
+
+/* Class = "NSMenuItem"; title = "75% of Ram"; ObjectID = "oUd-0o-jwy"; */
+"oUd-0o-jwy.title" = "RAM の 75%";
+
+/* Class = "NSMenu"; title = "Open Recent"; ObjectID = "oas-Oc-fiZ"; */
+"oas-Oc-fiZ.title" = "最近使った項目";
+
+/* Class = "NSMenuItem"; title = "Loosen"; ObjectID = "ogc-rX-tC1"; */
+"ogc-rX-tC1.title" = "Loosen";
+
+/* Class = "NSTableColumn"; headerCell.title = "Indexed"; ObjectID = "oqx-VA-7Zr"; */
+"oqx-VA-7Zr.headerCell.title" = "インデックス済み";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "pL4-3x-WFv"; */
+"pL4-3x-WFv.title" = "Text Cell";
+
+/* Class = "NSTextFieldCell"; title = "Warning: When a TmpDisk is ejected or the computer restarted all files on it will be permanently deleted. Please only store temporary files on a TmpDisk."; ObjectID = "pSH-sJ-D0k"; */
+"pSH-sJ-D0k.title" = "警告: TmpDisk を取り出すか、コンピュータを再起動すると、中にあるすべてのファイルは完全に削除されます。TmpDisk には一時的なファイルのみを保存してください。";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "pa3-QI-u2k"; */
+"pa3-QI-u2k.title" = "削除";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "pm4-Q2-gSs"; */
+"pm4-Q2-gSs.title" = "Text Cell";
+
+/* Class = "NSMenuItem"; title = "Save…"; ObjectID = "pxx-59-PXV"; */
+"pxx-59-PXV.title" = "保存…";
+
+/* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "q09-fT-Sye"; */
+"q09-fT-Sye.title" = "Find Next";
+
+/* Class = "NSTextFieldCell"; title = "TmpFS Root Folder"; ObjectID = "q71-xV-gGa"; */
+"q71-xV-gGa.title" = "TmpFS ルートフォルダ";
+
+/* Class = "NSMenuItem"; title = "Page Setup…"; ObjectID = "qIS-W8-SiK"; */
+"qIS-W8-SiK.title" = "ページの設定…";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "qXn-wF-aJV"; */
+"qXn-wF-aJV.title" = "Table View Cell";
+
+/* Class = "NSWindow"; title = "About"; ObjectID = "qkc-td-g2b"; */
+"qkc-td-g2b.title" = "情報";
+
+/* Class = "NSTextFieldCell"; title = "Folders"; ObjectID = "qw8-z7-vQx"; */
+"qw8-z7-vQx.title" = "フォルダ";
+
+/* Class = "NSMenuItem"; title = "Check Spelling While Typing"; ObjectID = "rbD-Rh-wIN"; */
+"rbD-Rh-wIN.title" = "Check Spelling While Typing";
+
+/* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "rgM-f4-ycn"; */
+"rgM-f4-ycn.title" = "Smart Dashes";
+
+/* Class = "NSMenuItem"; title = "Show Toolbar"; ObjectID = "snW-S8-Cw5"; */
+"snW-S8-Cw5.title" = "Show Toolbar";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "t3z-IH-wJR"; */
+"t3z-IH-wJR.title" = "Table View Cell";
+
+/* Class = "NSMenuItem"; title = "Data Detectors"; ObjectID = "tRr-pd-1PS"; */
+"tRr-pd-1PS.title" = "Data Detectors";
+
+/* Class = "NSMenuItem"; title = "Open Recent"; ObjectID = "tXI-mr-wws"; */
+"tXI-mr-wws.title" = "最近使った項目";
+
+/* Class = "NSMenu"; title = "Kern"; ObjectID = "tlD-Oa-oAM"; */
+"tlD-Oa-oAM.title" = "Kern";
+
+/* Class = "NSTextFieldCell"; title = "These volumes will be created automatically whenever TmpDisk starts"; ObjectID = "toS-Ay-uEq"; */
+"toS-Ay-uEq.title" = "TmpDisk が起動するたび、これらのボリュームは自動で作成されます";
+
+/* Class = "NSMenu"; title = "TmpDisk"; ObjectID = "uQy-DD-JDr"; */
+"uQy-DD-JDr.title" = "TmpDisk";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "uRl-iY-unG"; */
+"uRl-iY-unG.title" = "切り取り";
+
+/* Class = "NSMenuItem"; title = "25% of Ram"; ObjectID = "ud8-KO-JVf"; */
+"ud8-KO-JVf.title" = "RAM の 25%";
+
+/* Class = "NSMenuItem"; title = "Paste Style"; ObjectID = "vKC-jM-MkH"; */
+"vKC-jM-MkH.title" = "Paste Style";
+
+/* Class = "NSMenuItem"; title = "Show Ruler"; ObjectID = "vLm-3I-IUL"; */
+"vLm-3I-IUL.title" = "Show Ruler";
+
+/* Class = "NSMenuItem"; title = "Clear Menu"; ObjectID = "vNY-rz-j42"; */
+"vNY-rz-j42.title" = "Clear Menu";
+
+/* Class = "NSMenuItem"; title = "Make Upper Case"; ObjectID = "vmV-6d-7jI"; */
+"vmV-6d-7jI.title" = "Make Upper Case";
+
+/* Class = "NSMenu"; title = "Ligatures"; ObjectID = "w0m-vy-SC9"; */
+"w0m-vy-SC9.title" = "Ligatures";
+
+/* Class = "NSMenuItem"; title = "Align Right"; ObjectID = "wb2-vD-lq4"; */
+"wb2-vD-lq4.title" = "Align Right";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
+"wpr-3q-Mcd.title" = "ヘルプ";
+
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "x3v-GG-iWU"; */
+"x3v-GG-iWU.title" = "コピー";
+
+/* Class = "NSButtonCell"; title = "Use TmpFS (Needs Root Access)"; ObjectID = "xBA-Ze-bf2"; */
+"xBA-Ze-bf2.title" = "TmpFS 使用 (Needs Root Access)";
+
+/* Class = "NSMenuItem"; title = "Use All"; ObjectID = "xQD-1f-W4t"; */
+"xQD-1f-W4t.title" = "すべて使用";
+
+/* Class = "NSMenuItem"; title = "Speech"; ObjectID = "xrE-MZ-jX0"; */
+"xrE-MZ-jX0.title" = "Speech";
+
+/* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "z6F-FW-3nz"; */
+"z6F-FW-3nz.title" = "Show Substitutions";
+
+/* Class = "NSTextFieldCell"; title = "Installing the TmpDiskCreator Helper can install TmpFS TmpDisks without asking for your root password. Requires Admin password to install"; ObjectID = "LLv-lK-dgg"; */
+"LLv-lK-dgg.title" = "TmpDiskCreator ヘルパーをインストールすると、ルートのパスワードなしで TmpFS TmpDisks をインストールできます。インストールには管理者のパスワードが必要です。";


### PR DESCRIPTION
I translated it into Japanese.

However, I don't have MacOS, so please correct this if I'm wrong. I translated the AIM Toolkit first. For the tmpdisk UI, I referred to the following: [[1](https://applech2.com/archives/20250719-tmpdisk-for-mac-ram-disk-management.html)]. Some terms are the same as in Japanese MacOS.