### PR TITLE
2.3.0 release prep: root injection fix, Sparkle feed move, #58, signing

### DIFF
--- a/Common/Constants.swift
+++ b/Common/Constants.swift
@@ -13,6 +13,7 @@ struct Constant {
 
 enum TmpDiskError: Error {
     case noName
+    case invalidName
     case exists
     case invalidSize
     case failed

--- a/Common/DiskOperations.swift
+++ b/Common/DiskOperations.swift
@@ -150,7 +150,7 @@ class DiskOperations {
             try FileManager.default.createDirectory(atPath: volume.path(), withIntermediateDirectories: true, attributes: nil)
         }
 
-        var command = "mount_tmpfs -s\(volume.size)M \(volume.noExec ? "-o noexec " : "")\(volume.path())"
+        var command = "mount_tmpfs -s\(volume.size)M \(volume.noExec ? "-o noexec " : "")\"\(volume.path())\""
 
         // Fix ownership if running with elevated privileges
         if fixOwnership {
@@ -255,6 +255,10 @@ class DiskOperations {
         // Validation
         if volume.name.isEmpty {
             return .failure(.noName, message: "Volume name is required")
+        }
+
+        if !volume.hasValidName {
+            return .failure(.invalidName, message: "Volume name may only contain letters, numbers, spaces, and . _ -")
         }
 
         if volume.size <= 0 {

--- a/Common/TmpDiskVolume.swift
+++ b/Common/TmpDiskVolume.swift
@@ -37,6 +37,29 @@ struct TmpDiskVolume: Hashable, Codable {
     var hasSyncSource: Bool {
         return syncSource != nil && !syncSource!.isEmpty
     }
+
+    /// Characters permitted in a volume name. Restricted to a conservative
+    /// allowlist because the name is interpolated into shell commands that may
+    /// run as root via the privileged helper — any shell metacharacter (`;`,
+    /// `"`, `` ` ``, `$`, `/`, newlines, …) could otherwise enable command
+    /// injection. See DiskOperations.createTmpFsCommand / createRamDiskCommand.
+    static let allowedNameCharacters = CharacterSet(charactersIn:
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 _-.")
+
+    /// Returns true if `name` is safe to use for a volume: non-empty, not a
+    /// directory traversal token, and free of any character outside the
+    /// allowlist.
+    static func isValidName(_ name: String) -> Bool {
+        if name.isEmpty || name == "." || name == ".." {
+            return false
+        }
+        return name.unicodeScalars.allSatisfy { allowedNameCharacters.contains($0) }
+    }
+
+    /// Convenience: whether this volume's name passes `isValidName`.
+    var hasValidName: Bool {
+        return TmpDiskVolume.isValidName(name)
+    }
     
     init() {
         self.fileSystem = FileSystemManager.defaultFileSystemName()

--- a/TmpDisk.xcodeproj/project.pbxproj
+++ b/TmpDisk.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		22B88C402DA3303E00952C95 /* DiskSizeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B88C3E2DA3303700952C95 /* DiskSizeManager.swift */; };
 		22B88C4D2DA3500500952C95 /* TmpDiskCLI in CopyFiles */ = {isa = PBXBuildFile; fileRef = 22B88C452DA3495300952C95 /* TmpDiskCLI */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		22B88C4E2DA35D6100952C95 /* FileSystemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2283B6182D9F6B7B007A55F5 /* FileSystemManager.swift */; };
-		22D93DBE27B85E0F0024FB53 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D93DBD27B85E0F0024FB53 /* WindowManager.swift */; };
 		22CDE0012F24570100000001 /* TmpDiskConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDE0002F24570100000001 /* TmpDiskConfig.swift */; };
 		22CDE0022F24570100000002 /* TmpDiskConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDE0002F24570100000001 /* TmpDiskConfig.swift */; };
 		22CDE0032F24570100000003 /* DiskOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDE0002F24570100000003 /* DiskOperations.swift */; };
@@ -59,6 +58,7 @@
 		22CDE0062F24570100000006 /* TmpDiskVolume.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225587452B8FB23300136543 /* TmpDiskVolume.swift */; };
 		22CDE0072F24570100000007 /* DiskSizeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B88C3E2DA3303700952C95 /* DiskSizeManager.swift */; };
 		22CDE0082F24570100000008 /* DiskSizeManagerUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDE0002F24570100000008 /* DiskSizeManagerUI.swift */; };
+		22D93DBE27B85E0F0024FB53 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D93DBD27B85E0F0024FB53 /* WindowManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -926,7 +926,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = TmpDisk/TmpDisk.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1019;
@@ -960,11 +959,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = TmpDisk/TmpDisk.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1019;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = AGZ3AP53DM;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1147,7 +1146,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = TmpDiskLauncher/TmpDiskLauncher.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 10;
@@ -1181,7 +1179,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = TmpDiskLauncher/TmpDiskLauncher.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 10;

--- a/TmpDisk/Info.plist
+++ b/TmpDisk/Info.plist
@@ -11,10 +11,8 @@
 	<true/>
 	<key>SUFeedURL</key>
 	<string>https://appable.xyz/updates/tmpdisk.xml</string>
-	<key>SUPublicDSAKeyFile</key>
-	<string>dsa_pub.pem</string>
 	<key>SUPublicEDKey</key>
-	<string>cHYVa9jmyIHtzvsj9w8WQ/L19rbBklLx75GNou5ipjw=</string>
+	<string>Oj76xpgCiiykzzZm+ISCAS7G+XKFUGRDDZq0ylbGXiM=</string>
 	<key>TmpDiskHelperVersion</key>
 	<string>5</string>
 </dict>

--- a/TmpDisk/Info.plist
+++ b/TmpDisk/Info.plist
@@ -10,7 +10,7 @@
 	<key>SUEnableSystemProfiling</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://appable.xyz/updates/tmpdisk.xml</string>
+	<string>https://cmdline.io/appcast/tmpdisk.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>Oj76xpgCiiykzzZm+ISCAS7G+XKFUGRDDZq0ylbGXiM=</string>
 	<key>TmpDiskHelperVersion</key>

--- a/TmpDisk/TmpDiskManager.swift
+++ b/TmpDisk/TmpDiskManager.swift
@@ -89,6 +89,10 @@ class TmpDiskManager {
             return onCreate(.noName)
         }
 
+        if !volume.hasValidName {
+            return onCreate(.invalidName)
+        }
+
         if volume.size <= 0 {
             return onCreate(.invalidSize)
         }

--- a/TmpDisk/Views/NewTmpDiskViewController.swift
+++ b/TmpDisk/Views/NewTmpDiskViewController.swift
@@ -248,6 +248,9 @@ class NewTmpDiskViewController: NSViewController, NSTextFieldDelegate {
                     case .noName:
                         self.showError(message: NSLocalizedString("Your TmpDisk must have a name", comment: ""))
                         break;
+                    case .invalidName:
+                        self.showError(message: NSLocalizedString("Volume name may only contain letters, numbers, spaces, and . _ -", comment: ""))
+                        break;
                     case .exists:
                         self.showError(message: NSLocalizedString("A volume with this name already exists", comment: ""))
                         break;

--- a/TmpDiskCLI/main.swift
+++ b/TmpDiskCLI/main.swift
@@ -126,6 +126,20 @@ func executeEject(options: CLIOptions) {
         exit(1)
     }
 
+    // Honour warn-on-eject (#58): if the volume was created with --warn and still
+    // contains files, confirm before ejecting. --force skips the prompt for scripts.
+    if !options.force,
+       let volume = DiskOperations.findVolumeByName(volumeName),
+       volume.showWarning() {
+        print("Volume '\(volumeName)' has warn-on-eject enabled and still contains files.")
+        print("Eject anyway? [y/N] ", terminator: "")
+        let answer = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        if answer != "y" && answer != "yes" {
+            print("Eject cancelled.")
+            exit(0)
+        }
+    }
+
     let result = DiskOperations.ejectVolumeByName(volumeName, force: options.force)
 
     if result.success {

--- a/TmpDiskTests/TmpDiskTests.swift
+++ b/TmpDiskTests/TmpDiskTests.swift
@@ -17,7 +17,46 @@ class TmpDiskTests: XCTestCase {
             XCTAssertEqual(error!, TmpDiskError.noName)
         }
     }
-    
+
+    // MARK: - Volume name validation (shell-injection guard)
+
+    func testValidNamesAreAccepted() throws {
+        let valid = ["testvolume", "My Disk", "build.cache", "a-b_c.1", "RAM 2", "v2.3.0"]
+        for name in valid {
+            XCTAssertTrue(TmpDiskVolume.isValidName(name), "\"\(name)\" should be valid")
+        }
+    }
+
+    func testNamesWithShellMetacharactersAreRejected() throws {
+        // Each of these could break out of the shell commands run by the
+        // privileged helper as root if it were allowed through.
+        let invalid = [
+            "", ".", "..",
+            "a;b", "a\"b", "a`b", "a$b", "a/b", "a\\b",
+            "a&b", "a|b", "a(b)", "a>b", "a*b", "a'b",
+            "x; touch /tmp/pwned",
+            "$(whoami)",
+            "a\nb",
+        ]
+        for name in invalid {
+            XCTAssertFalse(TmpDiskVolume.isValidName(name), "\"\(name)\" should be rejected")
+        }
+    }
+
+    func testCreateTmpDiskRejectsInjectionName() throws {
+        let volume = TmpDiskVolume(name: "x; touch /tmp/tmpdisk_injection_test", size: 16)
+        var received: TmpDiskError?
+        // Invalid names short-circuit before any disk operation, so this
+        // callback runs synchronously.
+        TmpDiskManager.shared.createTmpDisk(volume: volume) { error in
+            received = error
+        }
+        XCTAssertEqual(received, TmpDiskError.invalidName)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: "/tmp/tmpdisk_injection_test"),
+                       "Injected command must not have executed")
+    }
+
+
     // MARK: - TmpDisk
     
     func testCreateTmpDiskSucceedsAndEjects() throws {

--- a/package.sh
+++ b/package.sh
@@ -15,5 +15,5 @@ npx appdmg@latest ./appdmg.json ./build/TmpDisk.dmg
 # Find the sparkle-project folder
 sparkle=$(find ~/Library/Developer/Xcode/DerivedData -maxdepth 1 -type d -print | grep -m1 'TmpDisk-')
 
-# Sign the dmg
-"$sparkle"/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast -f ./keys/dsa_priv.pem ./build
+# Generate appcast (uses EdDSA key from Keychain; import via keys/sparkle-keys.sh)
+"$sparkle"/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast ./build


### PR DESCRIPTION
Release prep for **2.3.0**: a root-privilege security fix, the Sparkle feed move, the #58 CLI bug, and signing/packaging config.

## Security (the blocker)
- **Validate volume names to prevent root shell injection.** Volume names were interpolated unsanitized into shell commands the privileged helper runs as root (and into an unquoted `mount_tmpfs` path). A crafted name (e.g. `x; touch /tmp/pwned`) could execute arbitrary commands as root, reachable from any same-user process via the predictable `/tmp/tmpdisk_cmd` pipe.
  - Strict allowlist (`A–Z a–z 0–9 space . _ -`) via `TmpDiskVolume.isValidName`, enforced at every creation entry point (GUI/pipe + CLI), new `.invalidName` error, and quoted the `mount_tmpfs` path as defense in depth.
  - Unit tests covering valid names, metacharacter rejection, and that an injection name never executes.

## Fixes
- **#58 — `-w/--warn` was a no-op on the CLI.** `eject` now prompts when a warn-on-eject volume still has files (`--force` skips it for scripts).

## Release config
- Point the Sparkle `SUFeedURL` at `https://cmdline.io/appcast/tmpdisk.xml`.
- Switch to automatic signing with `DEVELOPMENT_TEAM`; `generate_appcast` signs with the EdDSA key from the Keychain.

## Test plan
- [ ] Full test suite (note: TMPFS/noExec tests mount real disks and need the helper/admin)
- [ ] Verify a fresh 2.3.0 DMG opens clean on a machine that's never seen it (notarization)
