### PR TITLE
test: defang injection fixtures that tripped XProtect

### DIFF
--- a/TmpDiskTests/TmpDiskTests.swift
+++ b/TmpDiskTests/TmpDiskTests.swift
@@ -28,14 +28,17 @@ class TmpDiskTests: XCTestCase {
     }
 
     func testNamesWithShellMetacharactersAreRejected() throws {
-        // Each of these could break out of the shell commands run by the
-        // privileged helper as root if it were allowed through.
+        // Any name containing a shell metacharacter could break out of the
+        // shell commands the privileged helper runs as root, so each must be
+        // rejected. These are deliberately minimal `a<char>b` cases rather than
+        // realistic injection payloads: a compiled-in literal like
+        // "$(whoami)" or "; touch /tmp/..." trips antivirus (XProtect/YARA)
+        // heuristics on the test binary. Testing the disallowed character is
+        // exactly the property that matters — keep it that way.
         let invalid = [
             "", ".", "..",
             "a;b", "a\"b", "a`b", "a$b", "a/b", "a\\b",
             "a&b", "a|b", "a(b)", "a>b", "a*b", "a'b",
-            "x; touch /tmp/pwned",
-            "$(whoami)",
             "a\nb",
         ]
         for name in invalid {
@@ -43,8 +46,11 @@ class TmpDiskTests: XCTestCase {
         }
     }
 
-    func testCreateTmpDiskRejectsInjectionName() throws {
-        let volume = TmpDiskVolume(name: "x; touch /tmp/tmpdisk_injection_test", size: 16)
+    func testCreateTmpDiskRejectsInvalidName() throws {
+        // A name with a shell metacharacter must be rejected before any command
+        // is built. (Benign character-level input on purpose — see the note in
+        // testNamesWithShellMetacharactersAreRejected.)
+        let volume = TmpDiskVolume(name: "bad;name", size: 16)
         var received: TmpDiskError?
         // Invalid names short-circuit before any disk operation, so this
         // callback runs synchronously.
@@ -52,8 +58,6 @@ class TmpDiskTests: XCTestCase {
             received = error
         }
         XCTAssertEqual(received, TmpDiskError.invalidName)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: "/tmp/tmpdisk_injection_test"),
-                       "Injected command must not have executed")
     }
 
 


### PR DESCRIPTION
The volume-name validation tests (added in #59) embedded literal shell-injection payloads — `$(whoami)` and `x; touch /tmp/...`. When compiled into the `TmpDiskTests` binary, Apple's **XProtect** (YARA, ruleset v5347) pattern-matched those bytes as malware and **blocked the test run**. Confirmed via `strings` on the built `.xctest` bundle.

It was a false positive — nothing in the tests executes anything — but the fix is to not ship exploit-shaped strings in the binary:

- Replace the realistic payloads with minimal `a<char>b` inputs and a benign `bad;name`. These exercise the **exact same** property (a disallowed character is rejected before any command is built).
- Added a comment explaining why, so they don't get re-added.

Verified after rebuild: no `whoami` / `touch /tmp` / `pwned` / `injection` strings remain in the binary, and all three validation tests pass.
